### PR TITLE
Systemd unit: Use bluetooth.service instead of bluetooth.target

### DIFF
--- a/raspberry-pi/bluetooth-server.service
+++ b/raspberry-pi/bluetooth-server.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=bluetooth-server
-Requires=bluetooth.target
-After=bluetooth.target
+Requires=bluetooth.service
+After=bluetooth.service
 
 [Service]
 WorkingDirectory={{ working_directory }}


### PR DESCRIPTION
In my understanding, targets are meant for saying “start this unit when the target is requested”, i.e. for the “WantedBy” setting.

Otherwise, dependencies are implemented using services. That means we should be using the “bluetooth.service”, not the bluetooth target.

Note that in my environment (Ubuntu 20.04, 64bit) this worked with both configs, so it’d be ideal if you can test in your Raspbian environment.